### PR TITLE
Fix human feedback dict unwrapping

### DIFF
--- a/src/open_deep_research/graph.py
+++ b/src/open_deep_research/graph.py
@@ -175,7 +175,9 @@ def human_feedback(state: ReportState, config: RunnableConfig) -> Command[Litera
     feedback = interrupt(interrupt_message)
 
     if isinstance(feedback, dict):
-        feedback_val = feedback.get("feedback", feedback.get("value"))
+        feedback_val = feedback.get("feedback")
+        if not feedback_val:
+            feedback_val = feedback.get("value")
     else:
         feedback_val = feedback
 

--- a/src/open_deep_research/workflow/workflow.py
+++ b/src/open_deep_research/workflow/workflow.py
@@ -155,7 +155,9 @@ async def human_feedback(
     feedback = interrupt(interrupt_message)
 
     if isinstance(feedback, dict):
-        feedback_val = feedback.get("feedback", feedback.get("value"))
+        feedback_val = feedback.get("feedback")
+        if not feedback_val:
+            feedback_val = feedback.get("value")
     else:
         feedback_val = feedback
 


### PR DESCRIPTION
## Summary
- fix `human_feedback` to prefer `feedback` key when present and non-empty
- keep boolean and string logic the same

## Testing
- `ruff check . --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e5650d1e0832388e66106d0c805b3